### PR TITLE
Update to rc6 & code refactored

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,6 +35,9 @@ jobs:
           path: target
           key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
 
+      - name: Unleash clippy
+        run: cargo clippy -- -D warnings -A deprecated
+
       - name: Build Native
         run: cargo build
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,9 +35,6 @@ jobs:
           path: target
           key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Unleash clippy
-        run: cargo clippy -- -D warnings -A deprecated
-
       - name: Build Native
         run: cargo build
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,48 +4,45 @@ on: [pull_request]
 
 jobs:
 
-  ci:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: hecrj/setup-rust-action@v1
-        with:
-          rust-version: nightly
-          components: clippy, rustfmt
-          targets: wasm32-unknown-unknown
-      
-      - name: Checkout sources
-        uses: actions/checkout@v1
+	ci:
+		runs-on: ubuntu-latest
+		steps:
+			- uses: hecrj/setup-rust-action@v1
+				with:
+					rust-version: nightly
+					components: clippy, rustfmt
+					targets: wasm32-unknown-unknown
 
-      # Steps taken from https://github.com/actions/cache/blob/master/examples.md#rust---cargo
-      - name: Cache cargo registry
-        uses: actions/cache@v1
-        with:
-          path: ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+			- name: Checkout sources
+				uses: actions/checkout@v1
 
-      - name: Cache cargo index
-        uses: actions/cache@v1
-        with:
-          path: ~/.cargo/git
-          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+			# Steps taken from https://github.com/actions/cache/blob/master/examples.md#rust---cargo
+			- name: Cache cargo registry
+				uses: actions/cache@v1
+				with:
+					path: ~/.cargo/registry
+					key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Cache cargo build
-        uses: actions/cache@v1
-        with:
-          path: target
-          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+			- name: Cache cargo index
+				uses: actions/cache@v1
+				with:
+					path: ~/.cargo/git
+					key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Check Formatting
-        run: cargo fmt --all -- --check
+			- name: Cache cargo build
+				uses: actions/cache@v1
+				with:
+					path: target
+					key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Unleash clippy
-        run: cargo clippy -- -D warnings -A deprecated
+			- name: Unleash clippy
+				run: cargo clippy -- -D warnings -A deprecated
 
-      - name: Build Native
-        run: cargo build
+			- name: Build Native
+				run: cargo build
 
-      - name: Build Wasm
-        run: cargo +nightly build --target wasm32-unknown-unknown --no-default-features
+			- name: Build Wasm
+				run: cargo +nightly build --target wasm32-unknown-unknown --no-default-features
 
-      - name: Run tests
-        run: cargo test
+			- name: Run tests
+				run: cargo test

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,45 +4,45 @@ on: [pull_request]
 
 jobs:
 
-	ci:
-		runs-on: ubuntu-latest
-		steps:
-			- uses: hecrj/setup-rust-action@v1
-				with:
-					rust-version: nightly
-					components: clippy, rustfmt
-					targets: wasm32-unknown-unknown
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: hecrj/setup-rust-action@v1
+        with:
+          rust-version: nightly
+          components: clippy, rustfmt
+          targets: wasm32-unknown-unknown
 
-			- name: Checkout sources
-				uses: actions/checkout@v1
+      - name: Checkout sources
+        uses: actions/checkout@v1
 
-			# Steps taken from https://github.com/actions/cache/blob/master/examples.md#rust---cargo
-			- name: Cache cargo registry
-				uses: actions/cache@v1
-				with:
-					path: ~/.cargo/registry
-					key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+      # Steps taken from https://github.com/actions/cache/blob/master/examples.md#rust---cargo
+      - name: Cache cargo registry
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
 
-			- name: Cache cargo index
-				uses: actions/cache@v1
-				with:
-					path: ~/.cargo/git
-					key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+      - name: Cache cargo index
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
 
-			- name: Cache cargo build
-				uses: actions/cache@v1
-				with:
-					path: target
-					key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+      - name: Cache cargo build
+        uses: actions/cache@v1
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
 
-			- name: Unleash clippy
-				run: cargo clippy -- -D warnings -A deprecated
+      - name: Unleash clippy
+        run: cargo clippy -- -D warnings -A deprecated
 
-			- name: Build Native
-				run: cargo build
+      - name: Build Native
+        run: cargo build
 
-			- name: Build Wasm
-				run: cargo +nightly build --target wasm32-unknown-unknown --no-default-features
+      - name: Build Wasm
+        run: cargo +nightly build --target wasm32-unknown-unknown --no-default-features
 
-			- name: Run tests
-				run: cargo test
+      - name: Run tests
+        run: cargo test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-did"
-version = '2.0.0-rc4'
+version = '2.0.0-rc6'
 description = 'Substrate Decentralized ID Pallet'
 edition = '2018'
 authors = ['Substrate DevHub <https://github.com/substrate-developer-hub>']
@@ -11,55 +11,55 @@ license = 'Unlicense'
 [dependencies.serde]
 features = ['derive']
 optional = true
-version = '1.0.101'
+version = '1.0'
 
 [dependencies.codec]
 default-features = false
 features = ['derive']
 package = 'parity-scale-codec'
-version = '1.3.1'
+version = '1.3.4'
 
 [dependencies.sp-runtime]
 git = 'https://github.com/paritytech/substrate.git'
 default-features = false
-tag = 'v2.0.0-rc4'
-version = '2.0.0-rc4'
+tag = 'v2.0.0-rc6'
+version = '2.0.0-rc6'
 
 [dependencies.frame-support]
 git = 'https://github.com/paritytech/substrate.git'
 default-features = false
-tag = 'v2.0.0-rc4'
-version = '2.0.0-rc4'
+tag = 'v2.0.0-rc6'
+version = '2.0.0-rc6'
 
 [dependencies.frame-system]
 git = 'https://github.com/paritytech/substrate.git'
 default-features = false
-tag = 'v2.0.0-rc4'
-version = '2.0.0-rc4'
+tag = 'v2.0.0-rc6'
+version = '2.0.0-rc6'
 
 [dependencies.sp-io]
 git = 'https://github.com/paritytech/substrate.git'
 default-features = false
-tag = 'v2.0.0-rc4'
-version = '2.0.0-rc4'
+tag = 'v2.0.0-rc6'
+version = '2.0.0-rc6'
 
 [dependencies.sp-std]
 git = 'https://github.com/paritytech/substrate.git'
 default-features = false
-tag = 'v2.0.0-rc4'
-version = '2.0.0-rc4'
+tag = 'v2.0.0-rc6'
+version = '2.0.0-rc6'
 
 [dependencies.pallet-timestamp]
 git = 'https://github.com/paritytech/substrate.git'
 default_features = false
-tag = 'v2.0.0-rc4'
-version = '2.0.0-rc4'
+tag = 'v2.0.0-rc6'
+version = '2.0.0-rc6'
 
 [dependencies.sp-core]
 git = 'https://github.com/paritytech/substrate.git'
 default-features = false
-tag = 'v2.0.0-rc4'
-version = '2.0.0-rc4'
+tag = 'v2.0.0-rc6'
+version = '2.0.0-rc6'
 
 [features]
 default = ['std']

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,7 @@ use frame_support::{
 	StorageMap, Parameter
 };
 use frame_system::{self as system, ensure_signed};
-use sp_runtime::traits::{MaybeSerializeDeserialize, IdentifyAccount, Member, Verify, Saturating};
+use sp_runtime::traits::{IdentifyAccount, Verify, Saturating};
 use sp_std::{prelude::*, fmt, fmt::Debug};
 
 #[cfg(test)]
@@ -116,10 +116,10 @@ impl<T: Trait> fmt::Debug for AttributeUpdateTx<T> {
 }
 
 pub trait Trait: frame_system::Trait + pallet_timestamp::Trait {
-	type DId: Into<Self::AccountId> + Parameter + MaybeSerializeDeserialize + Debug + Default;
+	type DId: Into<Self::AccountId> + Parameter;
 	type Event: From<Event<Self>> + Into<<Self as frame_system::Trait>::Event>;
 	type Public: IdentifyAccount<AccountId = Self::AccountId>;
-	type Signature: Verify<Signer = Self::Public> + Member + Encode + Decode;
+	type Signature: Verify<Signer = Self::Public> + Parameter;
 }
 
 decl_event!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,12 +79,12 @@
 
 use codec::{Decode, Encode};
 use frame_support::{
-	decl_error, decl_event, decl_module, decl_storage, dispatch::DispatchResult, ensure, StorageMap,
-	Parameter
+	decl_error, decl_event, decl_module, decl_storage, dispatch::DispatchResult, ensure,
+	StorageMap, Parameter
 };
 use frame_system::{self as system, ensure_signed};
-use sp_runtime::traits::{MaybeSerializeDeserialize, IdentifyAccount, Member, Verify, MaybeDisplay,
-	Saturating};
+use sp_runtime::traits::{MaybeSerializeDeserialize, IdentifyAccount, Member, Verify,
+	MaybeDisplay, Saturating};
 use sp_std::{prelude::*, fmt, fmt::Debug};
 
 #[cfg(test)]
@@ -356,7 +356,8 @@ impl<T: Trait> Module<T> {
 
 		let delegate_vec = Self::delegate_of(did, delegate_type);
 		match delegate_vec.iter().find(|(acct, _)| acct == delegate) {
-			Some((_, exp_opt)) => exp_opt.map_or(true, |e| e <= <frame_system::Module<T>>::block_number()),
+			Some((_, exp_opt)) => exp_opt.map_or(true,
+				|valid_till| valid_till >= <frame_system::Module<T>>::block_number()),
 			None => false,
 		}
 	}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,524 +79,499 @@
 
 use codec::{Decode, Encode};
 use frame_support::{
-    decl_error, decl_event, decl_module, decl_storage, dispatch::DispatchResult, ensure, StorageMap,
+	decl_error, decl_event, decl_module, decl_storage, dispatch::DispatchResult, ensure, StorageMap,
+	Parameter,
 };
 use frame_system::{self as system, ensure_signed};
 use sp_core::RuntimeDebug;
 use sp_io::hashing::blake2_256;
-use sp_runtime::traits::{IdentifyAccount, Member, Verify};
-use sp_std::{prelude::*, vec::Vec};
+use sp_runtime::traits::{MaybeSerializeDeserialize, IdentifyAccount, Member, Verify, MaybeDisplay,
+	Saturating};
+use sp_std::{prelude::*, vec::Vec, fmt::Debug};
 
-#[cfg(test)]
-mod mock;
+// #[cfg(test)]
+// mod mock;
 
-#[cfg(test)]
-mod tests;
+// #[cfg(test)]
+// mod tests;
+
+const DELEGATE_TYPE_LEN: u32 = 64;
 
 /// Attributes or properties that make an identity.
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Decode, Default, RuntimeDebug)]
-pub struct Attribute<BlockNumber, Moment> {
-    pub name: Vec<u8>,
-    pub value: Vec<u8>,
-    pub validity: BlockNumber,
-    pub creation: Moment,
-    pub nonce: u64,
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Decode, Default)]
+pub struct Attribute<BlockNumber> {
+	pub name: Vec<u8>,
+	pub value: Vec<u8>,
+	pub created_at: BlockNumber,
+	pub valid_for: BlockNumber,
+	pub nonce: u64,
 }
 
-pub type AttributedId<BlockNumber, Moment> = (Attribute<BlockNumber, Moment>, [u8; 32]);
+/// This is the attribute with a 32-char hash
+pub type AttributedId<BlockNumber> = (Attribute<BlockNumber>, [u8; 32]);
 
 /// Off-chain signed transaction.
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Decode, Default, RuntimeDebug)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Decode, Default)]
 pub struct AttributeTransaction<Signature, AccountId> {
-    pub signature: Signature,
-    pub name: Vec<u8>,
-    pub value: Vec<u8>,
-    pub validity: u32,
-    pub signer: AccountId,
-    pub identity: AccountId,
+	pub signature: Signature,
+	pub name: Vec<u8>,
+	pub value: Vec<u8>,
+	pub validity: u32,
+	pub signer: AccountId,
+	pub identity: AccountId,
 }
 
 pub trait Trait: frame_system::Trait + pallet_timestamp::Trait {
-    type Event: From<Event<Self>> + Into<<Self as frame_system::Trait>::Event>;
-    type Public: IdentifyAccount<AccountId = Self::AccountId>;
-    type Signature: Verify<Signer = Self::Public> + Member + Decode + Encode;
-}
 
-decl_storage! {
-    trait Store for Module<T: Trait> as DID {
-        /// Identity delegates stored by type.
-        /// Delegates are only valid for a specific period defined as blocks number.
-        pub DelegateOf get(fn delegate_of): map hasher(blake2_128_concat) (T::AccountId, Vec<u8>, T::AccountId) => Option<T::BlockNumber>;
-        /// The attributes that belong to an identity.
-        /// Attributes are only valid for a specific period defined as blocks number.
-        pub AttributeOf get(fn attribute_of): map hasher(blake2_128_concat) (T::AccountId, [u8; 32]) => Attribute<T::BlockNumber, T::Moment>;
-        /// Attribute nonce used to generate a unique hash even if the attribute is deleted and recreated.
-        pub AttributeNonce get(fn nonce_of): map hasher(twox_64_concat) (T::AccountId, Vec<u8>) => u64;
-        /// Identity owner.
-        pub OwnerOf get(fn owner_of): map hasher(blake2_128_concat) T::AccountId => Option<T::AccountId>;
-        /// Tracking the latest identity update.
-        pub UpdatedBy get(fn updated_by): map hasher(blake2_128_concat) T::AccountId => (T::AccountId, T::BlockNumber, T::Moment);
-    }
-}
+	type DId: Parameter + Member + MaybeSerializeDeserialize + Debug + MaybeDisplay + Ord
+		+ Default;
 
-decl_module! {
-  pub struct Module<T: Trait> for enum Call where origin: T::Origin {
-      type Error = Error<T>;
-
-      fn deposit_event() = default;
-        /// Transfers ownership of an identity.
-        #[weight = 0]
-        pub fn change_owner(
-            origin,
-            identity: T::AccountId,
-            new_owner: T::AccountId,
-        ) -> DispatchResult {
-            let who = ensure_signed(origin)?;
-            Self::is_owner(&identity, &who)?;
-
-            let now_timestamp = <pallet_timestamp::Module<T>>::now();
-            let now_block_number = <frame_system::Module<T>>::block_number();
-
-            if <OwnerOf<T>>::contains_key(&identity) {
-                // Update to new owner.
-                <OwnerOf<T>>::mutate(&identity, |o| *o = Some(new_owner.clone()));
-            } else {
-                // Add to new owner.
-                <OwnerOf<T>>::insert(&identity, &new_owner);
-            }
-            // Save the update time and block.
-            <UpdatedBy<T>>::insert(
-                &identity, (&who, &now_block_number, &now_timestamp),
-            );
-            Self::deposit_event(RawEvent::OwnerChanged(
-                identity,
-                who,
-                new_owner,
-                now_block_number,
-            ));
-            Ok(())
-        }
-
-        /// Creates a new delegate with an expiration period and for a specific purpose.
-        #[weight = 0]
-        pub fn add_delegate(
-            origin,
-            identity: T::AccountId,
-            delegate: T::AccountId,
-            delegate_type: Vec<u8>,
-            valid_for: Option<T::BlockNumber>,
-        ) -> DispatchResult {
-            let who = ensure_signed(origin)?;
-            ensure!(delegate_type.len() <= 64, Error::<T>::InvalidDelegate);
-
-            Self::create_delegate( &who, &identity, &delegate, &delegate_type, valid_for)?;
-
-            let now_timestamp = <pallet_timestamp::Module<T>>::now();
-            let now_block_number = <frame_system::Module<T>>::block_number();
-            <UpdatedBy<T>>::insert(&identity, (who, now_block_number, now_timestamp));
-
-            Self::deposit_event(RawEvent::DelegateAdded(
-                identity,
-                delegate_type,
-                delegate,
-                valid_for,
-            ));
-            Ok(())
-        }
-
-        /// Revokes an identity's delegate by setting its expiration to the current block number.
-        #[weight = 0]
-        pub fn revoke_delegate(
-            origin,
-            identity: T::AccountId,
-            delegate_type: Vec<u8>,
-            delegate: T::AccountId,
-        ) -> DispatchResult {
-            let who = ensure_signed(origin)?;
-            Self::is_owner(&identity, &who)?;
-            Self::valid_listed_delegate(&identity, &delegate_type, &delegate)?;
-            ensure!(delegate_type.len() <= 64, Error::<T>::InvalidDelegate);
-
-            let now_timestamp = <pallet_timestamp::Module<T>>::now();
-            let now_block_number = <frame_system::Module<T>>::block_number();
-
-            // Update only the validity period to revoke the delegate.
-            <DelegateOf<T>>::mutate(
-                (&identity, &delegate_type, &delegate), |b| *b = Some(now_block_number),
-            );
-            <UpdatedBy<T>>::insert(&identity, (who, now_block_number, now_timestamp));
-            Self::deposit_event(RawEvent::DelegateRevoked(identity, delegate_type, delegate));
-            Ok(())
-        }
-
-        /// Creates a new attribute as part of an identity.
-        /// Sets its expiration period.
-        #[weight = 0]
-        pub fn add_attribute(
-            origin,
-            identity: T::AccountId,
-            name: Vec<u8>,
-            value: Vec<u8>,
-            valid_for: Option<T::BlockNumber>,
-        ) -> DispatchResult {
-            let who = ensure_signed(origin)?;
-            ensure!(name.len() <= 64, Error::<T>::AttributeCreationFailed);
-
-            Self::create_attribute(who, &identity, &name, &value, valid_for)?;
-            Self::deposit_event(RawEvent::AttributeAdded(identity, name, valid_for));
-            Ok(())
-        }
-
-        /// Revokes an attribute/property from an identity.
-        /// Sets its expiration period to the actual block number.
-        #[weight = 0]
-        pub fn revoke_attribute(origin, identity: T::AccountId, name: Vec<u8>) -> DispatchResult {
-            let who = ensure_signed(origin)?;
-            ensure!(name.len() <= 64, Error::<T>::AttributeRemovalFailed);
-
-            Self::reset_attribute(who, &identity, &name)?;
-            Self::deposit_event(RawEvent::AttributeRevoked(
-                identity,
-                name,
-                <frame_system::Module<T>>::block_number(),
-            ));
-            Ok(())
-        }
-
-        /// Removes an attribute from an identity. This attribute/property becomes unavailable.
-        #[weight = 0]
-        pub fn delete_attribute(origin, identity: T::AccountId, name: Vec<u8>) -> DispatchResult {
-            let who = ensure_signed(origin)?;
-            Self::is_owner(&identity, &who)?;
-            ensure!(name.len() <= 64, Error::<T>::AttributeRemovalFailed);
-
-            let now_block_number = <frame_system::Module<T>>::block_number();
-            let result = Self::attribute_and_id(&identity, &name);
-
-            match result {
-                Some((_, id)) => <AttributeOf<T>>::remove((&identity, &id)),
-                None => return Err(Error::<T>::AttributeRemovalFailed.into()),
-            }
-
-            <UpdatedBy<T>>::insert(
-                &identity,
-                (&who, &now_block_number, <pallet_timestamp::Module<T>>::now()),
-            );
-
-            Self::deposit_event(RawEvent::AttributeDeleted(identity, name, now_block_number));
-            Ok(())
-        }
-
-        /// Executes off-chain signed transaction.
-        #[weight = 0]
-        pub fn execute(
-            origin,
-            transaction: AttributeTransaction<T::Signature, T::AccountId>,
-        ) -> DispatchResult {
-            let who = ensure_signed(origin)?;
-
-            let mut encoded = transaction.name.encode();
-            encoded.extend(transaction.value.encode());
-            encoded.extend(transaction.validity.encode());
-            encoded.extend(transaction.identity.encode());
-
-            // Execute the storage update if the signer is valid.
-            Self::signed_attribute(who, &encoded, &transaction)?;
-            Self::deposit_event(RawEvent::AttributeTransactionExecuted(transaction));
-            Ok(())
-        }
-    }
+	type Event: From<Event<Self>> + Into<<Self as frame_system::Trait>::Event>;
+	type Public: IdentifyAccount<AccountId = Self::AccountId>;
+	type Signature: Verify<Signer = Self::Public> + Member + Encode + Decode;
 }
 
 decl_event!(
-  pub enum Event<T>
-  where
-  <T as frame_system::Trait>::AccountId,
-  <T as frame_system::Trait>::BlockNumber,
-  <T as Trait>::Signature
-  {
-    OwnerChanged(AccountId, AccountId, AccountId, BlockNumber),
-    DelegateAdded(AccountId, Vec<u8>, AccountId, Option<BlockNumber>),
-    DelegateRevoked(AccountId, Vec<u8>, AccountId),
-    AttributeAdded(AccountId,Vec<u8>, Option<BlockNumber>),
-    AttributeRevoked(AccountId,Vec<u8>,BlockNumber),
-    AttributeDeleted(AccountId,Vec<u8>,BlockNumber),
-    AttributeTransactionExecuted(AttributeTransaction<Signature,AccountId>),
-  }
+	pub enum Event<T> where
+		<T as frame_system::Trait>::AccountId,
+		<T as frame_system::Trait>::BlockNumber,
+		// <T as Trait>::Signature,
+		<T as Trait>::DId,
+	{
+		// params order: DId, the owner
+		DIdRegistered(DId, AccountId),
+		// params order: DId, the owner
+		DIdOwnerChanged(DId, AccountId),
+		// params order: DId, delegate type, target account, valid offset
+		DelegateUpserted(DId, Vec<u8>, AccountId, Option<BlockNumber>),
+		// params order: DId, delegate type, target account
+		DelegateRevoked(DId, Vec<u8>, AccountId),
+
+		// ---
+
+		// AttributeAdded(AccountId,Vec<u8>, Option<BlockNumber>),
+		// AttributeRevoked(AccountId,Vec<u8>,BlockNumber),
+		// AttributeDeleted(AccountId,Vec<u8>,BlockNumber),
+		// AttributeTransactionExecuted(AttributeTransaction<Signature,AccountId>),
+	}
 );
 
 decl_error! {
-    pub enum Error for Module<T: Trait> {
-        NotOwner,
-        InvalidDelegate,
-        BadSignature,
-        AttributeCreationFailed,
-        AttributeResetFailed,
-        AttributeRemovalFailed,
-        InvalidAttribute,
-        Overflow,
-        BadTransaction,
-    }
+	pub enum Error for Module<T: Trait> {
+		DelegateTypeTooLong,
+		DIdAlreadyExist,
+		DIdNotExist,
+		InvalidDelegate,
+		NotOwner,
+
+		// ---
+
+		// BadSignature,
+		// AttributeCreationFailed,
+		// AttributeResetFailed,
+		// AttributeRemovalFailed,
+		// InvalidAttribute,
+		// Overflow,
+		// BadTransaction,
+	}
+}
+
+decl_storage! {
+	trait Store for Module<T: Trait> as DId {
+		// Storing all the current registered DId
+		pub DIdStore get(fn did_store): map hasher(blake2_128_concat) T::DId => bool;
+
+		/// DId owner
+		pub OwnerOf get(fn owner_of): map hasher(blake2_128_concat) T::DId => Option<T::AccountId>;
+
+		/// The delegates of an identity. Only valid for a specific period as defined by block number.
+		pub DelegateOf get(fn delegate_of): double_map hasher(blake2_128_concat) T::DId,
+			hasher(blake2_128_concat) Vec<u8> => Vec<(T::AccountId, Option<T::BlockNumber>)>;
+
+		/// The attributes that belong to an identity. Only valid for a specific period as defined by
+		///   block number.
+		pub AttributeOf get(fn attribute_of): double_map hasher(blake2_128_concat) T::DId,
+			hasher(identity) Vec<u8> => Attribute<T::BlockNumber>;
+
+		/// Attribute nonce used to generate a unique hash even if the attribute is deleted and recreated.
+		pub AttributeNonce get(fn nonce_of): map hasher(blake2_128_concat) (T::DId, Vec<u8>) => u64;
+	}
+}
+
+decl_module! {
+	pub struct Module<T: Trait> for enum Call where origin: T::Origin {
+		type Error = Error<T>;
+		fn deposit_event() = default;
+
+		/// This function registers a new DId. The DId must not existed before
+		#[weight = 10000]
+		pub fn register_did(origin, did: T::DId) -> DispatchResult {
+			// check: this is a signed tx
+			let who = ensure_signed(origin)?;
+			// check: `did` doesn't exist in the store yet
+			ensure!(!Self::did_store(did), Error::<T>::DIdAlreadyExist)?;
+
+			// writes
+			<DIdStore<T>>::insert(&did, true);
+			<OwnerOf<T>>::insert(&did, Some(who));
+
+			// Emit event to notify DId is updated
+			Self::deposit_event(RawEvent::DIdRegistered(did, who));
+			Ok(())
+		}
+
+		/// This function registers a new DId. The DId must not existed before
+		#[weight = 10000]
+		pub fn change_owner(origin, did: T::DId, new_owner: T::AccountId) -> DispatchResult {
+			// check: this is a signed tx
+			let who = ensure_signed(origin)?;
+			// check: `did` exists in the store
+			ensure!(Self::did_store(did), Error::<T>::DIdNotExist)?;
+			// check: `who` is the owner of the DId
+			ensure!(Self::owner_of(did).map_or(false, |o| o == who), Error::<T>::NotOwner)?;
+
+			// writes
+			<OwnerOf<T>>::insert(&did, Some(new_owner));
+
+			// Emit event to notify DId is updated
+			Self::deposit_event(RawEvent::DIdOwnerChanged(did, new_owner));
+			Ok(())
+		}
+
+		/// Creates a new delegate with an expiration period and for a specific purpose.
+		// Either the did itself or the owner can add_delegate
+		#[weight = 10000]
+		pub fn upsert_delegate(origin, did: T::DId, delegate_type: Vec<u8>, delegate: T::AccountId,
+			valid_for_offset: Option<T::BlockNumber>) -> DispatchResult
+		{
+			// check: this is a signed tx
+			let who = ensure_signed(origin)?;
+			// check: `did` exists in the store
+			ensure!(Self::did_store(did), Error::<T>::DIdNotExist)?;
+			// check: `who` is the owner of the DId
+			ensure!(Self::owner_of(did).map_or(false, |o| o == who), Error::<T>::NotOwner)?;
+			// check: `who` cannot be the same as `delegate`
+			ensure!(who != delegate, Error::<T>::InvalidDelegate)?;
+			// check: the `delegate_type` length is within the limit
+			ensure!(delegate_type.len() <= DELEGATE_TYPE_LEN, Error::<T>::DelegateTypeTooLong);
+
+			// writes
+			Self::upsert_delegate_execute(&did, &delegate_type, &delegate, &valid_for_offset);
+
+			// emit successful event
+			Self::deposit_event(RawEvent::DelegateUpserted(did, delegate_type, delegate, valid_for_offset));
+			Ok(())
+		}
+
+		/// Revokes an identity's delegate by setting its expiration to the current block number.
+		#[weight = 10000]
+		pub fn revoke_delegate(origin, did: T::DId, delegate_type: Vec<u8>, delegate: T::AccountId)
+			-> DispatchResult
+		{
+			// check: this is a signed tx
+			let who = ensure_signed(origin)?;
+			// check: `did` exists in the store
+			ensure!(Self::did_store(did), Error::<T>::DIdNotExist)?;
+			// check: `who` is the owner of the DId
+			ensure!(Self::owner_of(did).map_or(false, |o| o == who), Error::<T>::NotOwner)?;
+			// check: `who` cannot be the same as `delegate`
+			ensure!(who != delegate, Error::<T>::InvalidDelegate)?;
+			// check: the `delegate_type` length is within the limit
+			ensure!(delegate_type.len() <= DELEGATE_TYPE_LEN, Error::<T>::DelegateTypeTooLong);
+
+			// writes
+			Self::revoke_delegate_execute(&did, &delegate_type, &delegate);
+
+			// emit successful event
+			Self::deposit_event(RawEvent::DelegateRevoked(did, delegate_type, delegate));
+			Ok(())
+		}
+
+		/// Creates a new attribute as part of an identity.
+		/// Sets its expiration period.
+		// #[weight = 10000]
+		// pub fn add_attribute(
+		// 	origin,
+		// 	identity: T::AccountId,
+		// 	name: Vec<u8>,
+		// 	value: Vec<u8>,
+		// 	valid_for: Option<T::BlockNumber>,
+		// ) -> DispatchResult {
+		// 	let who = ensure_signed(origin)?;
+		// 	ensure!(name.len() <= 64, Error::<T>::AttributeCreationFailed);
+
+		// 	Self::create_attribute(who, &identity, &name, &value, valid_for)?;
+		// 	Self::deposit_event(RawEvent::AttributeAdded(identity, name, valid_for));
+		// 	Ok(())
+		// }
+
+		/// Revokes an attribute/property from an identity.
+		/// Sets its expiration period to the actual block number.
+		// #[weight = 10000]
+		// pub fn revoke_attribute(origin, identity: T::AccountId, name: Vec<u8>) -> DispatchResult {
+		// 	let who = ensure_signed(origin)?;
+		// 	ensure!(name.len() <= 64, Error::<T>::AttributeRemovalFailed);
+
+		// 	Self::reset_attribute(who, &identity, &name)?;
+		// 	Self::deposit_event(RawEvent::AttributeRevoked(
+		// 		identity,
+		// 		name,
+		// 		<frame_system::Module<T>>::block_number(),
+		// 	));
+		// 	Ok(())
+		// }
+
+		/// Executes off-chain signed transaction.
+		// #[weight = 10000]
+		// pub fn execute(
+		// 	origin,
+		// 	transaction: AttributeTransaction<T::Signature, T::AccountId>,
+		// ) -> DispatchResult {
+		// 	let who = ensure_signed(origin)?;
+
+		// 	let mut encoded = transaction.name.encode();
+		// 	encoded.extend(transaction.value.encode());
+		// 	encoded.extend(transaction.validity.encode());
+		// 	encoded.extend(transaction.identity.encode());
+
+		// 	// Execute the storage update if the signer is valid.
+		// 	Self::signed_attribute(who, &encoded, &transaction)?;
+		// 	Self::deposit_event(RawEvent::AttributeTransactionExecuted(transaction));
+		// 	Ok(())
+		// }
+	}
 }
 
 impl<T: Trait> Module<T> {
-    /// Validates if the AccountId 'actual_owner' owns the identity.
-    pub fn is_owner(identity: &T::AccountId, actual_owner: &T::AccountId) -> DispatchResult {
-        let owner = Self::identity_owner(identity);
-        match owner == *actual_owner {
-            true => Ok(()),
-            false => Err(Error::<T>::NotOwner.into()),
-        }
-    }
+	/// Check if a delegate is valid for a (DId, delegate_type)
+	// the DId owner is always a valid delegate for all delegate_type at all time
+	pub fn valid_delegate(did: &T::DId, delegate_type: &[u8], delegate: &T::AccountId) -> bool {
 
-    /// Get the identity owner if set.
-    /// If never changed, returns the identity as its owner.
-    pub fn identity_owner(identity: &T::AccountId) -> T::AccountId {
-        match Self::owner_of(identity) {
-            Some(id) => id,
-            None => identity.clone(),
-        }
-    }
+		// DId does not exist
+		if !Self::did_store(did) { return false }
 
-    /// Validates if a delegate belongs to an identity and it has not expired.
-    pub fn valid_delegate(
-        identity: &T::AccountId,
-        delegate_type: &[u8],
-        delegate: &T::AccountId,
-    ) -> DispatchResult {
-        ensure!(delegate_type.len() <= 64, Error::<T>::InvalidDelegate);
-        ensure!(
-            Self::valid_listed_delegate(identity, delegate_type, delegate).is_ok()
-                || Self::is_owner(identity, delegate).is_ok(),
-            Error::<T>::InvalidDelegate
-        );
-        Ok(())
-    }
+		// `delegate` is the DId owner
+		if let Some(owner) = Self::owner_of(did) {
+			if owner == delegate { return true }
+		}
 
-    /// Validates that a delegate contains_key for specific purpose and remains valid at this block high.
-    pub fn valid_listed_delegate(
-        identity: &T::AccountId,
-        delegate_type: &[u8],
-        delegate: &T::AccountId,
-    ) -> DispatchResult {
-        ensure!(
-            <DelegateOf<T>>::contains_key((&identity, delegate_type, &delegate)),
-            Error::<T>::InvalidDelegate
-        );
+		let delegate_vec = Self::delegate_of((did, delegate_type));
+		match delegate_vec.find(|(acct, exp)| acct == delegate) {
+			Some((acct, exp)) => exp <= <frame_system::Module<T>>::block_number(),
+			None => false,
+		}
+	}
 
-        let validity = Self::delegate_of((identity, delegate_type, delegate));
-        match validity > Some(<frame_system::Module<T>>::block_number()) {
-            true => Ok(()),
-            false => Err(Error::<T>::InvalidDelegate.into()),
-        }
-    }
+	// Insert or update a delegete for a DId.
+	pub fn upsert_delegate_execute(
+		did: &T::DId,
+		delegate_type: &Vec<u8>,
+		delegate: &T::AccountId,
+		valid_for_offset: Option<T::BlockNumber>,
+	) {
+		let delegate_vec = Self::delegate_of(did, delegate_type);
 
-    // Creates a new delegete for an account.
-    pub fn create_delegate(
-        who: &T::AccountId,
-        identity: &T::AccountId,
-        delegate: &T::AccountId,
-        delegate_type: &Vec<u8>,
-        valid_for: Option<T::BlockNumber>,
-    ) -> DispatchResult {
-        Self::is_owner(&identity, who)?;
-        ensure!(who != delegate, Error::<T>::InvalidDelegate);
-        ensure!(
-            !Self::valid_listed_delegate(identity, delegate_type, delegate).is_ok(),
-            Error::<T>::InvalidDelegate
-        );
+		let new_exp_opt = valid_for_offset.map_or(None,
+			|offset| <frame_system::Module<T>>::block_number().saturating_add(offset));
 
-        let now_block_number = <frame_system::Module<T>>::block_number();
-        let validity: T::BlockNumber = match valid_for {
-            Some(blocks) => now_block_number + blocks,
-            None => u32::max_value().into(),
-        };
+		<DelegateOf<T>>::mutate(did, delegate_type, |vec| {
+			vec.filter_map( |(acct, orig_exp_opt)| if acct == delegate {
+				Some((acct, new_exp_opt))
+			} else {
+				Some((acct, orig_exp_opt))
+			});
+		});
+	}
 
-        <DelegateOf<T>>::insert(
-            (&identity, delegate_type, delegate), &validity,
-        );
-        Ok(())
-    }
+	pub fn revoke_delegate_execute(did: &T::DId, delegate_type: &Vec<u8>, delegate: &T::AccountId) {
+		<DelegateOf<T>>::mutate(did, delegate_type, |vec| {
+			vec.filter_map( |(acct, exp_opt)| if acct == delegate {
+				None
+			} else {
+				Some((acct, exp_opt))
+			})
+		});
+	}
 
-    /// Checks if a signature is valid. Used to validate off-chain transactions.
-    pub fn check_signature(
-        signature: &T::Signature,
-        msg: &[u8],
-        signer: &T::AccountId,
-    ) -> DispatchResult {
-        if signature.verify(msg, signer) {
-            Ok(())
-        } else {
-            Err(Error::<T>::BadSignature.into())
-        }
-    }
+	// /// Checks if a signature is valid. Used to validate off-chain transactions.
+	// pub fn check_signature(
+	// 	signature: &T::Signature,
+	// 	msg: &[u8],
+	// 	signer: &T::AccountId,
+	// ) -> DispatchResult {
+	// 	if signature.verify(msg, signer) {
+	// 		Ok(())
+	// 	} else {
+	// 		Err(Error::<T>::BadSignature.into())
+	// 	}
+	// }
 
-    /// Checks if a signature is valid. Used to validate off-chain transactions.
-    pub fn valid_signer(
-        identity: &T::AccountId,
-        signature: &T::Signature,
-        msg: &[u8],
-        signer: &T::AccountId,
-    ) -> DispatchResult {
-        // Owner or a delegate signer.
-        Self::valid_delegate(&identity, b"x25519VerificationKey2018", &signer)?;
-        Self::check_signature(&signature, &msg, &signer)
-    }
+	// /// Checks if a signature is valid. Used to validate off-chain transactions.
+	// pub fn valid_signer(
+	// 	identity: &T::AccountId,
+	// 	signature: &T::Signature,
+	// 	msg: &[u8],
+	// 	signer: &T::AccountId,
+	// ) -> DispatchResult {
+	// 	// Owner or a delegate signer.
+	// 	Self::valid_delegate(&identity, b"x25519VerificationKey2018", &signer)?;
+	// 	Self::check_signature(&signature, &msg, &signer)
+	// }
 
-    /// Adds a new attribute to an identity and colects the storage fee.
-    pub fn create_attribute(
-        who: T::AccountId,
-        identity: &T::AccountId,
-        name: &[u8],
-        value: &[u8],
-        valid_for: Option<T::BlockNumber>,
-    ) -> DispatchResult {
-        Self::is_owner(&identity, &who)?;
-        let now_timestamp = <pallet_timestamp::Module<T>>::now();
-        let now_block_number = <frame_system::Module<T>>::block_number();
-        let mut nonce = Self::nonce_of((&identity, name.to_vec()));
+	// /// Adds a new attribute to an identity and colects the storage fee.
+	// pub fn create_attribute(
+	// 	who: T::AccountId,
+	// 	identity: &T::AccountId,
+	// 	name: &[u8],
+	// 	value: &[u8],
+	// 	valid_for: Option<T::BlockNumber>,
+	// ) -> DispatchResult {
+	// 	Self::is_owner(&identity, &who)?;
+	// 	let now_timestamp = <pallet_timestamp::Module<T>>::now();
+	// 	let now_block_number = <frame_system::Module<T>>::block_number();
+	// 	let mut nonce = Self::nonce_of((&identity, name.to_vec()));
 
-        let validity: T::BlockNumber = match valid_for {
-            Some(blocks) => now_block_number + blocks,
-            None => u32::max_value().into(),
-        };
+	// 	let validity: T::BlockNumber = match valid_for {
+	// 		Some(blocks) => now_block_number + blocks,
+	// 		None => u32::max_value().into(),
+	// 	};
 
-        // Used for first time attribute creation
-        let lookup_nonce = match &nonce {
-            0 => 0, // prevents intialization panic
-            _ => &nonce - 1,
-        };
+	// 	// Used for first time attribute creation
+	// 	let lookup_nonce = match &nonce {
+	// 		0 => 0, // prevents intialization panic
+	// 		_ => &nonce - 1,
+	// 	};
 
-        let id = (&identity, name, lookup_nonce).using_encoded(blake2_256);
+	// 	let id = (&identity, name, lookup_nonce).using_encoded(blake2_256);
 
-        if <AttributeOf<T>>::contains_key((&identity, &id)) {
-            Err(Error::<T>::AttributeCreationFailed.into())
-        } else {
-            let new_attribute = Attribute {
-                name: (&name).to_vec(),
-                value: (&value).to_vec(),
-                validity,
-                creation: now_timestamp,
-                nonce,
-            };
+	// 	if <AttributeOf<T>>::contains_key((&identity, &id)) {
+	// 		Err(Error::<T>::AttributeCreationFailed.into())
+	// 	} else {
+	// 		let new_attribute = Attribute {
+	// 			name: (&name).to_vec(),
+	// 			value: (&value).to_vec(),
+	// 			validity,
+	// 			creation: now_timestamp,
+	// 			nonce,
+	// 		};
 
-            // Prevent panic overflow
-            nonce = nonce.checked_add(1).ok_or(Error::<T>::Overflow)?;
-            <AttributeOf<T>>::insert((&identity, &id), new_attribute);
-            <AttributeNonce<T>>::mutate((&identity, name.to_vec()), |n| *n = nonce);
-            <UpdatedBy<T>>::insert(
-                identity,
-                (
-                    who,
-                    <frame_system::Module<T>>::block_number(),
-                    <pallet_timestamp::Module<T>>::now(),
-                ),
-            );
-            Ok(())
-        }
-    }
+	// 		// Prevent panic overflow
+	// 		nonce = nonce.checked_add(1).ok_or(Error::<T>::Overflow)?;
+	// 		<AttributeOf<T>>::insert((&identity, &id), new_attribute);
+	// 		<AttributeNonce<T>>::mutate((&identity, name.to_vec()), |n| *n = nonce);
+	// 		<UpdatedBy<T>>::insert(
+	// 			identity,
+	// 			(
+	// 				who,
+	// 				<frame_system::Module<T>>::block_number(),
+	// 				<pallet_timestamp::Module<T>>::now(),
+	// 			),
+	// 		);
+	// 		Ok(())
+	// 	}
+	// }
 
-    /// Updates the attribute validity to make it expire and invalid.
-    pub fn reset_attribute(who: T::AccountId, identity: &T::AccountId, name: &[u8]) -> DispatchResult {
-        Self::is_owner(&identity, &who)?;
-        // If the attribute contains_key, the latest valid block is set to the current block.
-        let result = Self::attribute_and_id(identity, name);
-        match result {
-            Some((mut attribute, id)) => {
-                attribute.validity = <frame_system::Module<T>>::block_number();
-                <AttributeOf<T>>::mutate((&identity, id), |a| *a = attribute);
-            }
-            None => return Err(Error::<T>::AttributeResetFailed.into()),
-        }
+	// /// Updates the attribute validity to make it expire and invalid.
+	// pub fn reset_attribute(who: T::AccountId, identity: &T::AccountId, name: &[u8]) -> DispatchResult {
+	// 	Self::is_owner(&identity, &who)?;
+	// 	// If the attribute contains_key, the latest valid block is set to the current block.
+	// 	let result = Self::attribute_and_id(identity, name);
+	// 	match result {
+	// 		Some((mut attribute, id)) => {
+	// 			attribute.validity = <frame_system::Module<T>>::block_number();
+	// 			<AttributeOf<T>>::mutate((&identity, id), |a| *a = attribute);
+	// 		}
+	// 		None => return Err(Error::<T>::AttributeResetFailed.into()),
+	// 	}
 
-        // Keep track of the updates.
-        <UpdatedBy<T>>::insert(
-            identity,
-            (
-                who,
-                <frame_system::Module<T>>::block_number(),
-                <pallet_timestamp::Module<T>>::now(),
-            ),
-        );
-        Ok(())
-    }
+	// 	// Keep track of the updates.
+	// 	<UpdatedBy<T>>::insert(
+	// 		identity,
+	// 		(
+	// 			who,
+	// 			<frame_system::Module<T>>::block_number(),
+	// 			<pallet_timestamp::Module<T>>::now(),
+	// 		),
+	// 	);
+	// 	Ok(())
+	// }
 
-    /// Validates if an attribute belongs to an identity and it has not expired.
-    pub fn valid_attribute(identity: &T::AccountId, name: &[u8], value: &[u8]) -> DispatchResult {
-        ensure!(name.len() <= 64, Error::<T>::InvalidAttribute);
-        let result = Self::attribute_and_id(identity, name);
+	// /// Validates if an attribute belongs to an identity and it has not expired.
+	// pub fn valid_attribute(identity: &T::AccountId, name: &[u8], value: &[u8]) -> DispatchResult {
+	// 	ensure!(name.len() <= 64, Error::<T>::InvalidAttribute);
+	// 	let result = Self::attribute_and_id(identity, name);
 
-        let (attr, _) = match result {
-            Some((attr, id)) => (attr, id),
-            None => return Err(Error::<T>::InvalidAttribute.into()),
-        };
+	// 	let (attr, _) = match result {
+	// 		Some((attr, id)) => (attr, id),
+	// 		None => return Err(Error::<T>::InvalidAttribute.into()),
+	// 	};
 
-        if (attr.validity > (<frame_system::Module<T>>::block_number()))
-            && (attr.value == value.to_vec())
-        {
-            Ok(())
-        } else {
-            Err(Error::<T>::InvalidAttribute.into())
-        }
-    }
+	// 	if (attr.validity > (<frame_system::Module<T>>::block_number()))
+	// 		&& (attr.value == value.to_vec())
+	// 	{
+	// 		Ok(())
+	// 	} else {
+	// 		Err(Error::<T>::InvalidAttribute.into())
+	// 	}
+	// }
 
-    /// Returns the attribute and its hash identifier.
-    /// Uses a nonce to keep track of identifiers making them unique after attributes deletion.
-    pub fn attribute_and_id(
-        identity: &T::AccountId,
-        name: &[u8],
-    ) -> Option<AttributedId<T::BlockNumber, T::Moment>> {
-        let nonce = Self::nonce_of((&identity, name.to_vec()));
+	// /// Returns the attribute and its hash identifier.
+	// /// Uses a nonce to keep track of identifiers making them unique after attributes deletion.
+	// pub fn attribute_and_id(
+	// 	identity: &T::AccountId,
+	// 	name: &[u8],
+	// ) -> Option<AttributedId<T::BlockNumber, T::Moment>> {
+	// 	let nonce = Self::nonce_of((&identity, name.to_vec()));
 
-        // Used for first time attribute creation
-        let lookup_nonce = match nonce {
-            0u64 => 0, // prevents intialization panic
-            _ => nonce - 1u64,
-        };
+	// 	// Used for first time attribute creation
+	// 	let lookup_nonce = match nonce {
+	// 		0u64 => 0, // prevents intialization panic
+	// 		_ => nonce - 1u64,
+	// 	};
 
-        // Looks up for the existing attribute.
-        // Needs to use actual attribute nonce -1.
-        let id = (&identity, name, lookup_nonce).using_encoded(blake2_256);
+	// 	// Looks up for the existing attribute.
+	// 	// Needs to use actual attribute nonce -1.
+	// 	let id = (&identity, name, lookup_nonce).using_encoded(blake2_256);
 
-        if <AttributeOf<T>>::contains_key((&identity, &id)) {
-            Some((Self::attribute_of((identity, id)), id))
-        } else {
-            None
-        }
-    }
+	// 	if <AttributeOf<T>>::contains_key((&identity, &id)) {
+	// 		Some((Self::attribute_of((identity, id)), id))
+	// 	} else {
+	// 		None
+	// 	}
+	// }
 
-    /// Creates a new attribute from a off-chain transaction.
-    fn signed_attribute(
-        who: T::AccountId,
-        encoded: &[u8],
-        transaction: &AttributeTransaction<T::Signature, T::AccountId>,
-    ) -> DispatchResult {
-        // Verify that the Data was signed by the owner or a not expired signer delegate.
-        Self::valid_signer(
-            &transaction.identity,
-            &transaction.signature,
-            &encoded,
-            &transaction.signer,
-        )?;
-        Self::is_owner(&transaction.identity, &transaction.signer)?;
-        ensure!(transaction.name.len() <= 64, Error::<T>::BadTransaction);
+	// /// Creates a new attribute from a off-chain transaction.
+	// fn signed_attribute(
+	// 	who: T::AccountId,
+	// 	encoded: &[u8],
+	// 	transaction: &AttributeTransaction<T::Signature, T::AccountId>,
+	// ) -> DispatchResult {
+	// 	// Verify that the Data was signed by the owner or a not expired signer delegate.
+	// 	Self::valid_signer(
+	// 		&transaction.identity,
+	// 		&transaction.signature,
+	// 		&encoded,
+	// 		&transaction.signer,
+	// 	)?;
+	// 	Self::is_owner(&transaction.identity, &transaction.signer)?;
+	// 	ensure!(transaction.name.len() <= 64, Error::<T>::BadTransaction);
 
-        let now_block_number = <frame_system::Module<T>>::block_number();
-        let validity = now_block_number + transaction.validity.into();
+	// 	let now_block_number = <frame_system::Module<T>>::block_number();
+	// 	let validity = now_block_number + transaction.validity.into();
 
-        // If validity was set to 0 in the transaction,
-        // it will set the attribute latest valid block to the actual block.
-        if validity > now_block_number {
-            Self::create_attribute(
-                who,
-                &transaction.identity,
-                &transaction.name,
-                &transaction.value,
-                Some(transaction.validity.into()),
-            )?;
-        } else {
-            Self::reset_attribute(who, &transaction.identity, &transaction.name)?;
-        }
-        Ok(())
-    }
+	// 	// If validity was set to 0 in the transaction,
+	// 	// it will set the attribute latest valid block to the actual block.
+	// 	if validity > now_block_number {
+	// 		Self::create_attribute(
+	// 			who,
+	// 			&transaction.identity,
+	// 			&transaction.name,
+	// 			&transaction.value,
+	// 			Some(transaction.validity.into()),
+	// 		)?;
+	// 	} else {
+	// 		Self::reset_attribute(who, &transaction.identity, &transaction.name)?;
+	// 	}
+	// 	Ok(())
+	// }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,64 +15,59 @@
 //!
 //! ## Overview
 //!
-//! The DID pallet provides functionality for DIDs management.
+//! The DId (Decentralized ID) pallet provides functionality for DIds management.
 //!
-//! * Change Identity Owner
+//! * Register a DId
+//! * Change the DId Owner
 //! * Add Delegate
 //! * Revoke Delegate
 //! * Add Attribute
 //! * Revoke Attribute
-//! * Delete Attribute
-//! * Off-Chain Attribute Management
+//! * DId attribute update from off-chain transaction signature
 //!
 //! ### Terminology
 //!
-//! * **DID:** A Decentralized Identifiers/Identity compliant with the DID standard.
-//!     The DID is an AccountId with associated attributes/properties.
-//! * **Identity Ownership** By default an identity is owned by itself, meaning whoever controls the account with that key.
-//!     The owner can be updated to a new key pair.
-//! * **Delegate:** A Delegate recives delegated permissions from a DID for a specific purpose.
-//! * **Attribute:** It is a feature that gives extra information of an identity.
-//! * **Valid Delegate:** The action of obtaining the validity period of the delegate.
-//! * **Valid Attribute:** The action of obtaining the validity period of an attribute.
-//! * **Change Identity Owner:** The process of transferring ownership.
-//! * **Add Delegate:** The process of adding delegate privileges to an identity.
-//!     An identity can assign multiple delegates for specific purposes on its behalf.
-//! * **Revoke Delegate:** The process of revoking delegate privileges from an identity.
-//! * **Add Attribute:** The process of assigning a specific identity attribute or feature.
-//! * **Revoke Attribute:** The process of revoking a specific identity attribute or feature.
-//! * **Delete Attribute:** The process of deleting a specific identity attribute or feature.
+//! * **DId:** A Decentralized Identifiers/Identity compliant with the DID standard.
+//!     The DId is an AccountId with associated attributes/properties.
+//! * **Identity Ownership** The owner of the DId. It is the signer who called `register_did` dispatchable
+//!     method. The owner has to own the private key of the DId and send a message and its corresponding
+//!     signature by DId when registering.
+//! * **Delegate:** A Delegate receives delegated permissions from a DId for a specific purpose, represented
+//!    as `delegate_type`, in the code. The delegation can be valid indefinitely or valid for a certain
+//!    time period, represented by `BlockNumber`.
+//! * **Attribute:** It is a feature that gives extra information of a DId. Each attribute is a key, value
+//!     pair. The attribute can be valid indefinitely or valid for a certain time period, represented by
+//!    `BlockNumber`.
 //!
 //! ### Goals
 //!
 //! The DID system in Substrate is designed to make the following possible:
 //!
-//! * A decentralized identity or self-sovereign identity is a new approach where no one but you owns or controls the state of your digital identity.
+//! * A decentralized identity or self-sovereign identity is a new approach where no one but you owns
+//    or controls the state of your claimed digital identity.
 //! * It enables the possibility to create a portable, persistent,  privacy-protecting, and personal identity.
 //!
 //! ### Dispatchable Functions
 //!
-//! * `change_owner` - Transfers an `identity` represented as an `AccountId` from the owner account (`origin`) to a `target` account.
-//! * `add_delegate` - Creates a new delegate with an expiration period and for a specific purpose.
-//! * `revoke_delegate` - Revokes an identity's delegate by setting its expiration to the current block number.
-//! * `add_attribute` - Creates a new attribute/property as part of an identity. Sets its expiration period.
-//! * `revoke_attribute` - Revokes an attribute/property from an identity. Sets its expiration period to the actual block number.
-//! * `delete_attribute` - Removes an attribute/property from an identity. This attribute/property becomes unavailable.
-//! * `execute` - Executes off-chain signed transactions.
+//! * `register_did` - Register a DId. The DId should not have been claimed before, and the caller should
+//!    have the private key of the DId to make a signature.
+//! * `change_owner` - Transfers the DId ownership to someone else.
+//! * `upsert_delegate` - Create/update a new delegate with an expiration period for a specific purpose
+//!   (`delegate_type`).
+//! * `revoke_delegate` - Revokes a DId delegate for a specific purpose (`delegate_type`).
+//! * `upsert_attribute` - Create/update a new attribute/property as part of an identity and its its expiration period.
+//! * `revoke_attribute` - Revokes an attribute/property from an identity.
+//! * `upsert_attribute_from_offchain_signature` - Executes off-chain signed transactions to upsert the attribute
+//!   by the DId owner or delegate.
 //!
 //! ### Public Functions
 //!
-//! * `is_owner` - Returns a boolean value. `True` if the `account` owns the `identity`.
-//! * `identity_owner` - Get the account owner of an `identity`.
-//! * `valid_delegate` - Validates if a delegate belongs to an identity and it has not expired.
-//!    The identity owner has all provileges and is considered as delegate with all permissions.
-//! * `valid_listed_delegate` - Returns a boolean value. `True` if the `delegate` belongs the `identity` delegates list.
-//! * `valid_attribute` - Validates if an attribute belongs to an identity and it has not expired.
-//! * `attribute_and_id` - Get the `attribute` and its `hash` identifier.
-//! * `check_signature` - Validates the signer from a signature.
-//! * `valid_signer` - Validates a signature from a valid signer delegate or the owner of an identity.
-//!
-//! *
+//! * `valid_delegate` - Validates if a user is a valid delegate for a `delegate_type`. The owner is
+//!    always a valid delegate of its owned DId. Return `true` or `false`.
+//! * `valid_attribute` - Validates if an attribute/property is valid for the DId. The function return
+//!    `true` only when both the key and value match, and the property is before its expiration period.
+//! * `encode_dnvv` - This method encodes DId, attribute name, attribute value, and expiration period
+//!    into a message to be signed. This method is used when in `upsert_attribute_from_offchain_signature`.
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![recursion_limit = "256"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,20 +50,22 @@
 //!
 //! ### Dispatchable Functions
 //!
-//! * `change_owner` - Transfers the DId ownership to another account.
+//! * `change_owner` - Transfer the DId ownership to another account.
 //! * `upsert_delegate` - Create/update a new delegate with an expiration period for a specific purpose
 //!   (`delegate_type`).
-//! * `revoke_delegate` - Revokes a DId delegate for a specific purpose (`delegate_type`).
+//! * `revoke_delegate` - Revoke a DId delegate for a specific purpose (`delegate_type`).
 //! * `upsert_attribute` - Create/update a new attribute/property as part of an identity and its its expiration period.
-//! * `revoke_attribute` - Revokes an attribute/property from an identity.
-//! * `upsert_attribute_from_offchain_signature` - Executes off-chain signed transactions to upsert the attribute
+//! * `revoke_attribute` - Revoke an attribute/property from an identity.
+//! * `upsert_attribute_from_offchain_signature` - Execute off-chain signed transactions to upsert the attribute
 //!   by the DId owner or delegate.
 //!
 //! ### Public Functions
 //!
-//! * `valid_delegate` - Validates if a user is a valid delegate for a `delegate_type`. The owner is
+//! * `did_owned` - Check whether a DId is owned by the user. Return a `bool` value.
+//! * `did_owner` - Retrieve the DId owner. Return a `T::AccounId` value.
+//! * `valid_delegate` - Check if a user is a valid delegate for a `delegate_type`. The owner is
 //!    always a valid delegate of its owned DId. Return `true` or `false`.
-//! * `valid_attribute` - Validates if an attribute/property is valid for the DId. The function return
+//! * `valid_attribute` - Check if an attribute/property is valid for the DId. The function return
 //!    `true` only when both the key and value match, and the property is before its expiration period.
 //! * `encode_dnvv` - This method encodes DId, attribute name, attribute value, and expiration period
 //!    into a message to be signed. This method is used when in `upsert_attribute_from_offchain_signature`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,8 +83,6 @@ use frame_support::{
 	Parameter
 };
 use frame_system::{self as system, ensure_signed};
-// use sp_core::RuntimeDebug;
-// use sp_io::hashing::blake2_256;
 use sp_runtime::traits::{MaybeSerializeDeserialize, IdentifyAccount, Member, Verify, MaybeDisplay,
 	Saturating};
 use sp_std::{prelude::*, vec::Vec, fmt::Debug};

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -52,12 +52,14 @@ impl system::Trait for Test {
 	type AccountData = ();
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
 }
 
 impl timestamp::Trait for Test {
 	type Moment = u64;
 	type OnTimestampSet = ();
 	type MinimumPeriod = ();
+	type WeightInfo = ();
 }
 
 impl Trait for Test {

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -65,7 +65,6 @@ impl timestamp::Trait for Test {
 impl Trait for Test {
 	type DId = sr25519::Public;
 	type Event = ();
-	type Public = sr25519::Public;
 	type Signature = sr25519::Signature;
 }
 

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -61,12 +61,13 @@ impl timestamp::Trait for Test {
 }
 
 impl Trait for Test {
+	type DId = sr25519::Public;
 	type Event = ();
 	type Public = sr25519::Public;
 	type Signature = sr25519::Signature;
 }
 
-pub type DID = Module<Test>;
+pub type DId = Module<Test>;
 pub type System = system::Module<Test>;
 
 // This function basically just builds a genesis storage key/value store according to

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -1,18 +1,18 @@
 use crate::{Module, Trait};
 use frame_support::{
-  impl_outer_origin, parameter_types, weights::Weight,
+	impl_outer_origin, parameter_types, weights::Weight,
 };
 use frame_system as system;
 use pallet_timestamp as timestamp;
 use sp_core::{sr25519, Pair, H256};
 use sp_runtime::{
-    testing::Header,
-    traits::{BlakeTwo256, IdentityLookup},
-    Perbill,
+	testing::Header,
+	traits::{BlakeTwo256, IdentityLookup},
+	Perbill,
 };
 
 impl_outer_origin! {
-  pub enum Origin for Test {}
+	pub enum Origin for Test {}
 }
 
 // For testing the pallet, we construct most of a mock runtime. This means
@@ -21,49 +21,49 @@ impl_outer_origin! {
 #[derive(Clone, Eq, PartialEq)]
 pub struct Test;
 parameter_types! {
-  pub const BlockHashCount: u64 = 250;
-  pub const MaximumBlockWeight: Weight = 1024;
-  pub const MaximumBlockLength: u32 = 2 * 1024;
-  pub const AvailableBlockRatio: Perbill = Perbill::from_percent(75);
+	pub const BlockHashCount: u64 = 250;
+	pub const MaximumBlockWeight: Weight = 1024;
+	pub const MaximumBlockLength: u32 = 2 * 1024;
+	pub const AvailableBlockRatio: Perbill = Perbill::from_percent(75);
 }
 
 impl system::Trait for Test {
-  type BaseCallFilter = ();
-  type Origin = Origin;
-  type Call = ();
-  type Index = u64;
-  type BlockNumber = u64;
-  type Hash = H256;
-  type Hashing = BlakeTwo256;
-  type AccountId = sr25519::Public;
-  type Lookup = IdentityLookup<Self::AccountId>;
-  type Header = Header;
-  type Event = ();
-  type BlockHashCount = BlockHashCount;
-  type MaximumBlockWeight = MaximumBlockWeight;
-  type DbWeight = ();
-  type BlockExecutionWeight = ();
-  type ExtrinsicBaseWeight = ();
-  type MaximumExtrinsicWeight = MaximumBlockWeight;
-  type MaximumBlockLength = MaximumBlockLength;
-  type AvailableBlockRatio = AvailableBlockRatio;
-  type Version = ();
-  type ModuleToIndex = ();
-  type AccountData = ();
-  type OnNewAccount = ();
-  type OnKilledAccount = ();
+	type BaseCallFilter = ();
+	type Origin = Origin;
+	type Call = ();
+	type Index = u64;
+	type BlockNumber = u64;
+	type Hash = H256;
+	type Hashing = BlakeTwo256;
+	type AccountId = sr25519::Public;
+	type Lookup = IdentityLookup<Self::AccountId>;
+	type Header = Header;
+	type Event = ();
+	type BlockHashCount = BlockHashCount;
+	type MaximumBlockWeight = MaximumBlockWeight;
+	type DbWeight = ();
+	type BlockExecutionWeight = ();
+	type ExtrinsicBaseWeight = ();
+	type MaximumExtrinsicWeight = MaximumBlockWeight;
+	type MaximumBlockLength = MaximumBlockLength;
+	type AvailableBlockRatio = AvailableBlockRatio;
+	type Version = ();
+	type ModuleToIndex = ();
+	type AccountData = ();
+	type OnNewAccount = ();
+	type OnKilledAccount = ();
 }
 
 impl timestamp::Trait for Test {
-    type Moment = u64;
-    type OnTimestampSet = ();
-    type MinimumPeriod = ();
+	type Moment = u64;
+	type OnTimestampSet = ();
+	type MinimumPeriod = ();
 }
 
 impl Trait for Test {
-    type Event = ();
-    type Public = sr25519::Public;
-    type Signature = sr25519::Signature;
+	type Event = ();
+	type Public = sr25519::Public;
+	type Signature = sr25519::Signature;
 }
 
 pub type DID = Module<Test>;
@@ -72,18 +72,18 @@ pub type System = system::Module<Test>;
 // This function basically just builds a genesis storage key/value store according to
 // our desired mockup.
 pub fn new_test_ext() -> sp_io::TestExternalities {
-    system::GenesisConfig::default()
-        .build_storage::<Test>()
-        .unwrap()
-        .into()
+	system::GenesisConfig::default()
+		.build_storage::<Test>()
+		.unwrap()
+		.into()
 }
 
 pub fn account_pair(s: &str) -> sr25519::Pair {
-    sr25519::Pair::from_string(&format!("//{}", s), None).expect("static values are valid; qed")
+	sr25519::Pair::from_string(&format!("//{}", s), None).expect("static values are valid; qed")
 }
 
 pub fn account_key(s: &str) -> sr25519::Public {
-    sr25519::Pair::from_string(&format!("//{}", s), None)
-        .expect("static values are valid; qed")
-        .public()
+	sr25519::Pair::from_string(&format!("//{}", s), None)
+		.expect("static values are valid; qed")
+		.public()
 }

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -78,12 +78,8 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 		.into()
 }
 
-pub fn account_pair(s: &str) -> sr25519::Pair {
-	sr25519::Pair::from_string(&format!("//{}", s), None).expect("static values are valid; qed")
-}
-
-pub fn account_key(s: &str) -> sr25519::Public {
-	sr25519::Pair::from_string(&format!("//{}", s), None)
-		.expect("static values are valid; qed")
-		.public()
+pub fn account(s: &str) -> (sr25519::Pair, sr25519::Public) {
+	let pair = sr25519::Pair::from_string(&format!("//{}", s), None)
+		.expect("static values are valid; qed");
+	(pair.clone(), pair.public())
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -4,207 +4,120 @@ use frame_support::{assert_noop, assert_ok};
 use sp_core::Pair;
 
 #[test]
-fn validate_claim() {
-    new_test_ext().execute_with(|| {
-        let value = b"I am Satoshi Nakamoto".to_vec();
+fn validate_owner_signature() {
+	new_test_ext().execute_with(|| {
+		// Create a DId account
+		let (_, did_public) = account("My Organization");
 
-        // Create a new account pair and get the public key.
-        let satoshi_pair = account_pair("Satoshi");
-        let satoshi_public = satoshi_pair.public();
+		// Create a new account pair and public key
+		let (satoshi_pair, satoshi_public) = account("Satoshi");
 
-        // Encode and sign the claim message.
-        let claim = value.encode();
-        let satoshi_sig = satoshi_pair.sign(&claim);
+		// Test: Should be able to register a new DId
+		assert_ok(!DID::register_did(Origin::signed(satoshi_public.clone()), did_public));
 
-        // Validate that "Satoshi" signed the message.
-        assert_ok!(DID::valid_signer(
-            &satoshi_public,
-            &satoshi_sig,
-            &claim,
-            &satoshi_public
-        ));
+		// Encode and sign a message.
+		let msg = "I am Satoshi Nakamoto".encode();
+		let satoshi_sig = satoshi_pair.sign(&msg);
 
-        // Create a different public key to test the signature.
-        let bobtc_public = account_key("Bob");
+		// Test: Should accept DId's owner signature
+		assert(DID::valid_signer_and_signature(&did_public, &satoshi_sig, &msg, &satoshi_public));
 
-        // Fail to validate that Bob signed the message.
-        assert_noop!(
-            DID::check_signature(&satoshi_sig, &claim, &bobtc_public),
-            Error::<Test>::BadSignature
-        );
-    });
+		// Test: Should not accept someone masquerading as the owner, Satoshi
+		let (bob_pair, _) = account("Bob");
+		let bob_sig = bob_pair.sign(&msg);
+
+		assert(!DID::valid_signer_and_signature(&did_public, &bob_sig, &msg, &satoshi_public));
+	});
 }
 
 #[test]
-fn validate_delegated_claim() {
-    new_test_ext().execute_with(|| {
-        System::set_block_number(1);
+fn validate_delegate_signature() {
+	new_test_ext().execute_with(|| {
+		System::set_block_number(1);
 
-        // Predefined delegate type: "Sr25519VerificationKey2018"
-        let delegate_type = b"x25519VerificationKey2018".to_vec();
-        let data = b"I am Satoshi Nakamoto".to_vec();
+		// Create a DId account
+		let (_, did_public) = account("My Organization");
 
-        let satoshi_public = account_key("Satoshi"); // Get Satoshi's public key.
-        let nakamoto_pair = account_pair("Nakamoto"); // Create a new delegate account pair.
-        let nakamoto_public = nakamoto_pair.public(); // Get delegate's public key.
+		// Create a new account pair and public key
+		let (satoshi_pair, satoshi_public) = account("Satoshi");
+		let (bob_pair, bob_public) = account("Bob");
 
-        // Add signer delegate
-        assert_ok!(
-            DID::add_delegate(
-                Origin::signed(satoshi_public.clone()),
-                satoshi_public.clone(),  // owner
-                nakamoto_public.clone(), // new signer delgate
-                delegate_type.clone(),   // "Sr25519VerificationKey2018"
-                Some(5)
-            ) // valid for 5 blocks
-        );
+		assert_ok(!DID::register_did(Origin::signed(satoshi_public.clone()), did_public));
 
-        let claim = data.encode();
-        let satoshi_sig = nakamoto_pair.sign(&claim); // Sign the data with delegate private key.
+		let valid_block_offset = 5;
 
-        System::set_block_number(3);
+		// Test: Adding Bob as delegate should succeed
+		assert_ok(!DID::upsert_delegate(Origin::signed(satoshi_public.clone()),
+			did_public, crate::OFFCHAIN_TX_DELEGATE_TYPE, bob_public, Some(valid_block_offset)));
 
-        // Validate that satoshi's delegate signed the message.
-        assert_ok!(DID::valid_signer(
-            &satoshi_public,
-            &satoshi_sig,
-            &claim,
-            &nakamoto_public
-        ));
+		let msg = "I am Satoshi Nakamoto".encode();
+		let bob_sig = bob_pair.sign(&msg);
 
-        System::set_block_number(6);
+		System::set_block_number(valid_block_offset + 1);
 
-        // Delegate became invalid at block 6
-        assert_noop!(
-            DID::valid_signer(&satoshi_public, &satoshi_sig, &claim, &nakamoto_public),
-            Error::<Test>::InvalidDelegate
-        );
-    });
+		// Test: The delegate signature should be valid during the delegation period
+		assert(DID::valid_signer_and_signature(&did_public, &bob_public, &msg, &bob_sig));
+
+		System::set_block_number(valid_block_offset + 2);
+
+		// Test: The delegate signature should fail after the delegation period
+		assert(!DID::valid_signer_and_signature(&did_public, &bob_public, &msg, &bob_sig));
+	});
 }
 
-#[test]
-fn add_on_chain_and_revoke_off_chain_attribute() {
-    new_test_ext().execute_with(|| {
-        let name = b"MyAttribute".to_vec();
-        let mut value = [1, 2, 3].to_vec();
-        let mut validity: u32 = 1000;
+// #[test]
+// fn add_on_chain_and_revoke_off_chain_attribute() {
+// 	new_test_ext().execute_with(|| {
+// 		let name = b"MyAttribute".to_vec();
+// 		let mut value = [1, 2, 3].to_vec();
+// 		let mut validity: u32 = 1000;
 
-        // Create a new account pair and get the public key.
-        let alice_pair = account_pair("Alice");
-        let alice_public = alice_pair.public();
+// 		// Create a new account pair and get the public key.
+// 		let alice_pair = account_pair("Alice");
+// 		let alice_public = alice_pair.public();
 
-        // Add a new attribute to an identity. Valid until block 1 + 1000.
-        assert_ok!(DID::add_attribute(
-            Origin::signed(alice_public.clone()),
-            alice_public.clone(),
-            name.clone(),
-            value.clone(),
-            Some(validity.clone().into())
-        ));
+// 		// Add a new attribute to an identity. Valid until block 1 + 1000.
+// 		assert_ok!(DID::add_attribute(
+// 			Origin::signed(alice_public.clone()),
+// 			alice_public.clone(),
+// 			name.clone(),
+// 			value.clone(),
+// 			Some(validity.clone().into())
+// 		));
 
-        // Validate that the attribute contains_key and has not expired.
-        assert_ok!(DID::valid_attribute(&alice_public, &name, &value));
+// 		// Validate that the attribute contains_key and has not expired.
+// 		assert_ok!(DID::valid_attribute(&alice_public, &name, &value));
 
-        // Revoke attribute off-chain
-        // Set validity to 0 in order to revoke the attribute.
-        validity = 0;
-        value = [0].to_vec();
-        let mut encoded = name.encode();
-        encoded.extend(value.encode());
-        encoded.extend(validity.encode());
-        encoded.extend(alice_public.encode());
+// 		// Revoke attribute off-chain
+// 		// Set validity to 0 in order to revoke the attribute.
+// 		validity = 0;
+// 		value = [0].to_vec();
+// 		let mut encoded = name.encode();
+// 		encoded.extend(value.encode());
+// 		encoded.extend(validity.encode());
+// 		encoded.extend(alice_public.encode());
 
-        let revoke_sig = alice_pair.sign(&encoded);
+// 		let revoke_sig = alice_pair.sign(&encoded);
 
-        let revoke_transaction = AttributeTransaction {
-            signature: revoke_sig,
-            name: name.clone(),
-            value: value.clone(),
-            validity,
-            signer: alice_public.clone(),
-            identity: alice_public.clone(),
-        };
+// 		let revoke_transaction = AttributeTransaction {
+// 			signature: revoke_sig,
+// 			name: name.clone(),
+// 			value: value.clone(),
+// 			validity,
+// 			signer: alice_public.clone(),
+// 			identity: alice_public.clone(),
+// 		};
 
-        // Revoke with off-chain signed transaction.
-        assert_ok!(DID::execute(
-            Origin::signed(alice_public.clone()),
-            revoke_transaction
-        ));
+// 		// Revoke with off-chain signed transaction.
+// 		assert_ok!(DID::execute(
+// 			Origin::signed(alice_public.clone()),
+// 			revoke_transaction
+// 		));
 
-        // Validate that the attribute was revoked.
-        assert_noop!(
-            DID::valid_attribute(&alice_public, &name, &[1, 2, 3].to_vec()),
-            Error::<Test>::InvalidAttribute
-        );
-    });
-}
-
-#[test]
-fn attacker_to_transfer_identity_should_fail() {
-    new_test_ext().execute_with(|| {
-        // Attacker is not the owner
-        assert_eq!(
-            DID::identity_owner(&account_key("Alice")),
-            account_key("Alice")
-        );
-
-        // Transfer identity ownership to attacker
-        assert_noop!(
-            DID::change_owner(
-                Origin::signed(account_key("BadBoy")),
-                account_key("Alice"),
-                account_key("BadBoy")
-            ),
-            Error::<Test>::NotOwner
-        );
-
-        // Attacker is not the owner
-        assert_noop!(
-            DID::is_owner(&account_key("Alice"), &account_key("BadBoy")),
-            Error::<Test>::NotOwner
-        );
-
-        // Verify that the owner never changed
-        assert_eq!(
-            DID::identity_owner(&account_key("Alice")),
-            account_key("Alice")
-        );
-    });
-}
-
-#[test]
-fn attacker_add_new_delegate_should_fail() {
-    new_test_ext().execute_with(|| {
-        // BadBoy is an invalid delegate previous to attack.
-        assert_noop!(
-            DID::valid_delegate(
-                &account_key("Alice"),
-                &vec![7, 7, 7],
-                &account_key("BadBoy")
-            ),
-            Error::<Test>::InvalidDelegate
-        );
-
-        // Attacker should fail to add delegate.
-        assert_noop!(
-            DID::add_delegate(
-                Origin::signed(account_key("BadBoy")),
-                account_key("Alice"),
-                account_key("BadBoy"),
-                vec![7, 7, 7],
-                Some(20)
-            ),
-            Error::<Test>::NotOwner
-        );
-
-        // BadBoy is an invalid delegate.
-        assert_noop!(
-            DID::valid_delegate(
-                &account_key("Alice"),
-                &vec![7, 7, 7],
-                &account_key("BadBoy")
-            ),
-            Error::<Test>::InvalidDelegate
-        );
-    });
-}
+// 		// Validate that the attribute was revoked.
+// 		assert_noop!(
+// 			DID::valid_attribute(&alice_public, &name, &[1, 2, 3].to_vec()),
+// 			Error::<Test>::InvalidAttribute
+// 		);
+// 	});
+// }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -42,7 +42,7 @@ fn allows_owner_attr_update_tx() {
 }
 
 #[test]
-fn validate_delegate_signature() {
+fn allows_delegate_attr_update_tx() {
 	new_test_ext().execute_with(|| {
 		System::set_block_number(1);
 
@@ -50,7 +50,7 @@ fn validate_delegate_signature() {
 		let (_, did_public) = account("My Organization");
 
 		// Create a new account pair and public key
-		let (satoshi_pair, satoshi_public) = account("Satoshi");
+		let (_, satoshi_public) = account("Satoshi");
 		let (bob_pair, bob_public) = account("Bob");
 
 		assert_ok!(DId::register_did(Origin::signed(satoshi_public.clone()), did_public));
@@ -65,5 +65,26 @@ fn validate_delegate_signature() {
 			bob_public,
 			Some(valid_block_offset)
 		));
+
+		System::set_block_number(1 + valid_block_offset);
+
+		// Test: Bob now be able to send attr_update_tx
+		let name = b"attribute name";
+		let value = b"attribute value";
+		let msg = DId::encode_dnvv(&did_public, name, value, None);
+		let tx_bob = AttributeUpdateTx {
+			did: did_public,
+			name: name.to_vec(),
+			value: value.to_vec(),
+			valid_till: None,
+			signature: bob_pair.sign(&msg)
+		};
+		assert_ok!(DId::execute(Origin::signed(bob_public.clone()), tx_bob.clone()));
+
+		// Now, Bob valid period has passed
+		System::set_block_number(2 + valid_block_offset);
+		// Test: This tx should fail
+		assert_noop!(DId::execute(Origin::signed(bob_public.clone()), tx_bob),
+			Error::<Test>::InvalidDelegate);
 	});
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -3,7 +3,97 @@ use frame_support::{assert_noop, assert_ok};
 use sp_core::Pair;
 
 #[test]
-fn allows_owner_attr_update_tx() {
+fn allows_registering_did_with_valid_signature() {
+	new_test_ext().execute_with(|| {
+		let (did_pair, did_public) = account("My Organization");
+		let (satoshi_pair, satoshi_public) = account("Satoshi");
+		let reg_msg = b"did registration";
+
+		// Test 1: Test with invalid signature - should fail. The signature should be from
+		//   did private key, not Satoshi private key.
+		assert_noop!(DId::register_did(
+			Origin::signed(satoshi_public.clone()),
+			did_public,
+			reg_msg.to_vec(),
+			satoshi_pair.sign(reg_msg)
+		), Error::<Test>::InvalidSignature);
+
+		// Test 2: Test with valid signature - should succeed
+		assert_ok!(DId::register_did(
+			Origin::signed(satoshi_public.clone()),
+			did_public,
+			reg_msg.to_vec(),
+			did_pair.sign(reg_msg)
+		));
+
+		// Test 3: Test with DId registration the duplicate DId - should fail
+		assert_noop!(DId::register_did(
+			Origin::signed(satoshi_public.clone()),
+			did_public,
+			reg_msg.to_vec(),
+			did_pair.sign(reg_msg)
+		), Error::<Test>::DIdAlreadyExist);
+	})
+}
+
+#[test]
+fn change_did_owner() {
+	new_test_ext().execute_with(|| {
+		// Setup: Satoshi create a DId
+		let (did_pair, did_public) = account("My Organization");
+		let (_, satoshi_public) = account("Satoshi");
+		let reg_msg = b"did registration";
+		let del_type = b"del_type";
+
+		assert_ok!(DId::register_did(
+			Origin::signed(satoshi_public.clone()),
+			did_public,
+			reg_msg.to_vec(),
+			did_pair.sign(reg_msg)
+		));
+
+		// Test 1: Bob try to upsert DId delegate for Charles. This should fail
+		let (_, bob_public) = account("Bob");
+		let (_, charles_public) = account("Charles");
+
+		assert_noop!(DId::upsert_delegate(
+			Origin::signed(bob_public.clone()),
+			did_public,
+			del_type.to_vec(),
+			charles_public,
+			None
+		), Error::<Test>::NotOwner);
+
+		// Satoshi pass the DId ownership to Bob
+		assert_ok!(DId::change_owner(
+			Origin::signed(satoshi_public.clone()),
+			did_public,
+			bob_public,
+		));
+
+		// Test 2: Bob try to upsert DId delegate for Charles. This should succeed
+		assert_ok!(DId::upsert_delegate(
+			Origin::signed(bob_public.clone()),
+			did_public,
+			del_type.to_vec(),
+			charles_public,
+			None
+		));
+
+		// Test 3: Satoshi try to upsert DId delegate for Charles. This should fail, as he
+		//   is no longer the DId owner
+		assert_noop!(DId::upsert_delegate(
+			Origin::signed(satoshi_public.clone()),
+			did_public,
+			del_type.to_vec(),
+			charles_public,
+			None
+		), Error::<Test>::NotOwner);
+	})
+}
+
+#[test]
+fn accepts_owner_attr_update_tx() {
 	new_test_ext().execute_with(|| {
 		// Create a DId account
 		let (did_pair, did_public) = account("My Organization");
@@ -13,7 +103,7 @@ fn allows_owner_attr_update_tx() {
 
 		let reg_msg = b"did registration";
 
-		// Test: Should be able to register a new DId
+		// Register a DId
 		assert_ok!(DId::register_did(
 			Origin::signed(satoshi_public.clone()),
 			did_public,
@@ -21,7 +111,7 @@ fn allows_owner_attr_update_tx() {
 			did_pair.sign(reg_msg)
 		));
 
-		// Test: Should accept DId's owner signature
+		// Test #1: Should accept DId's owner signature
 		let name = b"attribute name";
 		let value = b"attribute value";
 		let dnvv_msg = DId::encode_dnvv(&did_public, name, value, None);
@@ -34,10 +124,10 @@ fn allows_owner_attr_update_tx() {
 		};
 		assert_ok!(DId::upsert_attribute_from_offchain_signature(
 			Origin::signed(satoshi_public.clone()),
-			tx_satoshi
+			tx_satoshi.clone()
 		));
 
-		// Test: Should not accept other ppl to update
+		// Test #2: Should not accept other ppl to update
 		let (bob_pair, bob_public) = account("Bob");
 		let tx_bob = AttributeUpdateTx {
 			did: did_public,
@@ -50,11 +140,26 @@ fn allows_owner_attr_update_tx() {
 			Origin::signed(bob_public.clone()),
 			tx_bob
 		), Error::<Test>::InvalidDelegate);
+
+		// Test #3: Should not accept Bob masquerading as Satoshi.
+		//   To test this, we need to give Bob upsert_attribute right first
+		assert_ok!(DId::upsert_delegate(
+			Origin::signed(satoshi_public.clone()),
+			did_public,
+			crate::OFFCHAIN_TX_DELEGATE_TYPE.to_vec(),
+			bob_public,
+			None
+		));
+
+		assert_noop!(DId::upsert_attribute_from_offchain_signature(
+			Origin::signed(bob_public.clone()),
+			tx_satoshi
+		), Error::<Test>::InvalidSignature);
 	});
 }
 
 #[test]
-fn allows_delegate_attr_update_tx() {
+fn accepts_delegate_attr_update_tx() {
 	new_test_ext().execute_with(|| {
 		System::set_block_number(1);
 
@@ -66,6 +171,7 @@ fn allows_delegate_attr_update_tx() {
 		let (bob_pair, bob_public) = account("Bob");
 		let reg_msg = b"did registration";
 
+		// Setup: Satoshi registers a DId
 		assert_ok!(DId::register_did(
 			Origin::signed(satoshi_public.clone()),
 			did_public,
@@ -75,7 +181,7 @@ fn allows_delegate_attr_update_tx() {
 
 		let valid_block_offset = 5;
 
-		// Test: Adding Bob as delegate should succeed
+		// Setup: Satoshi upsert Bob as DId delegate
 		assert_ok!(DId::upsert_delegate(
 			Origin::signed(satoshi_public.clone()),
 			did_public,
@@ -86,7 +192,7 @@ fn allows_delegate_attr_update_tx() {
 
 		System::set_block_number(1 + valid_block_offset);
 
-		// Test: Bob now be able to send attr_update_tx
+		// Test #1: Bob now should be able to send attr_update_tx
 		let name = b"attribute name";
 		let value = b"attribute value";
 		let msg = DId::encode_dnvv(&did_public, name, value, None);
@@ -102,9 +208,8 @@ fn allows_delegate_attr_update_tx() {
 			tx_bob.clone()
 		));
 
-		// Now, Bob valid period has passed
+		// Test #2: Bob valid period has passed. Now the transaction should fail.
 		System::set_block_number(2 + valid_block_offset);
-		// Test: This tx should fail
 		assert_noop!(DId::upsert_attribute_from_offchain_signature(
 			Origin::signed(bob_public.clone()),
 			tx_bob

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -3,59 +3,15 @@ use frame_support::{assert_noop, assert_ok};
 use sp_core::Pair;
 
 #[test]
-fn allows_registering_did_with_valid_signature() {
-	new_test_ext().execute_with(|| {
-		let (did_pair, did_public) = account("My Organization");
-		let (satoshi_pair, satoshi_public) = account("Satoshi");
-		let reg_msg = b"did registration";
-
-		// Test 1: Test with invalid signature - should fail. The signature should be from
-		//   did private key, not Satoshi private key.
-		assert_noop!(DId::register_did(
-			Origin::signed(satoshi_public.clone()),
-			did_public,
-			reg_msg.to_vec(),
-			satoshi_pair.sign(reg_msg)
-		), Error::<Test>::InvalidSignature);
-
-		// Test 2: Test with valid signature - should succeed
-		assert_ok!(DId::register_did(
-			Origin::signed(satoshi_public.clone()),
-			did_public,
-			reg_msg.to_vec(),
-			did_pair.sign(reg_msg)
-		));
-
-		// Test 3: Test with DId registration the duplicate DId - should fail
-		assert_noop!(DId::register_did(
-			Origin::signed(satoshi_public.clone()),
-			did_public,
-			reg_msg.to_vec(),
-			did_pair.sign(reg_msg)
-		), Error::<Test>::DIdAlreadyExist);
-	})
-}
-
-#[test]
 fn change_did_owner() {
 	new_test_ext().execute_with(|| {
-		// Setup: Satoshi create a DId
-		let (did_pair, did_public) = account("My Organization");
-		let (_, satoshi_public) = account("Satoshi");
-		let reg_msg = b"did registration";
+		// Setup
 		let del_type = b"del_type";
-
-		assert_ok!(DId::register_did(
-			Origin::signed(satoshi_public.clone()),
-			did_public,
-			reg_msg.to_vec(),
-			did_pair.sign(reg_msg)
-		));
-
-		// Test 1: Bob try to upsert DId delegate for Charles. This should fail
+		let (_, did_public) = account("My Organization");
 		let (_, bob_public) = account("Bob");
 		let (_, charles_public) = account("Charles");
 
+		// Test 1: Bob try to upsert DId delegate for Charles. This should fail as it is owned by DId now.
 		assert_noop!(DId::upsert_delegate(
 			Origin::signed(bob_public.clone()),
 			did_public,
@@ -64,9 +20,9 @@ fn change_did_owner() {
 			None
 		), Error::<Test>::NotOwner);
 
-		// Satoshi pass the DId ownership to Bob
+		// DId itself pass the ownership to Bob
 		assert_ok!(DId::change_owner(
-			Origin::signed(satoshi_public.clone()),
+			Origin::signed(did_public.clone()),
 			did_public,
 			bob_public,
 		));
@@ -80,10 +36,10 @@ fn change_did_owner() {
 			None
 		));
 
-		// Test 3: Satoshi try to upsert DId delegate for Charles. This should fail, as he
+		// Test 3: DId now try to upsert DId delegate for Charles. This should fail, as he
 		//   is no longer the DId owner
 		assert_noop!(DId::upsert_delegate(
-			Origin::signed(satoshi_public.clone()),
+			Origin::signed(did_public.clone()),
 			did_public,
 			del_type.to_vec(),
 			charles_public,
@@ -95,40 +51,27 @@ fn change_did_owner() {
 #[test]
 fn accepts_owner_attr_update_tx() {
 	new_test_ext().execute_with(|| {
-		// Create a DId account
+		// Setup
 		let (did_pair, did_public) = account("My Organization");
-
-		// Create a new account pair and public key
-		let (satoshi_pair, satoshi_public) = account("Satoshi");
-
-		let reg_msg = b"did registration";
-
-		// Register a DId
-		assert_ok!(DId::register_did(
-			Origin::signed(satoshi_public.clone()),
-			did_public,
-			reg_msg.to_vec(),
-			did_pair.sign(reg_msg)
-		));
-
-		// Test #1: Should accept DId's owner signature
+		let (bob_pair, bob_public) = account("Bob");
 		let name = b"attribute name";
 		let value = b"attribute value";
 		let dnvv_msg = DId::encode_dnvv(&did_public, name, value, None);
-		let tx_satoshi = AttributeUpdateTx {
+
+		// Test #1: Should accept DId's owner signature
+		let tx_did = AttributeUpdateTx {
 			did: did_public,
 			name: name.to_vec(),
 			value: value.to_vec(),
 			valid_till: None,
-			signature: satoshi_pair.sign(&dnvv_msg)
+			signature: did_pair.sign(&dnvv_msg)
 		};
 		assert_ok!(DId::upsert_attribute_from_offchain_signature(
-			Origin::signed(satoshi_public.clone()),
-			tx_satoshi.clone()
+			Origin::signed(did_public.clone()),
+			tx_did.clone()
 		));
 
 		// Test #2: Should not accept other ppl to update
-		let (bob_pair, bob_public) = account("Bob");
 		let tx_bob = AttributeUpdateTx {
 			did: did_public,
 			name: name.to_vec(),
@@ -141,10 +84,10 @@ fn accepts_owner_attr_update_tx() {
 			tx_bob
 		), Error::<Test>::InvalidDelegate);
 
-		// Test #3: Should not accept Bob masquerading as Satoshi.
-		//   To test this, we need to give Bob upsert_attribute right first
+		// Test #3: Should not accept Bob masquerading as DId.
+		//   To test this, we need to first give Bob upsert_attribute right
 		assert_ok!(DId::upsert_delegate(
-			Origin::signed(satoshi_public.clone()),
+			Origin::signed(did_public.clone()),
 			did_public,
 			crate::OFFCHAIN_TX_DELEGATE_TYPE.to_vec(),
 			bob_public,
@@ -153,7 +96,7 @@ fn accepts_owner_attr_update_tx() {
 
 		assert_noop!(DId::upsert_attribute_from_offchain_signature(
 			Origin::signed(bob_public.clone()),
-			tx_satoshi
+			tx_did
 		), Error::<Test>::InvalidSignature);
 	});
 }
@@ -161,29 +104,15 @@ fn accepts_owner_attr_update_tx() {
 #[test]
 fn accepts_delegate_attr_update_tx() {
 	new_test_ext().execute_with(|| {
+		// Setup
 		System::set_block_number(1);
-
-		// Create a DId account
-		let (did_pair, did_public) = account("My Organization");
-
-		// Create a new account pair and public key
-		let (_, satoshi_public) = account("Satoshi");
+		let (_, did_public) = account("My Organization");
 		let (bob_pair, bob_public) = account("Bob");
-		let reg_msg = b"did registration";
-
-		// Setup: Satoshi registers a DId
-		assert_ok!(DId::register_did(
-			Origin::signed(satoshi_public.clone()),
-			did_public,
-			reg_msg.to_vec(),
-			did_pair.sign(reg_msg)
-		));
-
 		let valid_block_offset = 5;
 
-		// Setup: Satoshi upsert Bob as DId delegate
+		// Setup: DId upsert Bob as DId delegate
 		assert_ok!(DId::upsert_delegate(
-			Origin::signed(satoshi_public.clone()),
+			Origin::signed(did_public.clone()),
 			did_public,
 			crate::OFFCHAIN_TX_DELEGATE_TYPE.to_vec(),
 			bob_public,
@@ -208,7 +137,7 @@ fn accepts_delegate_attr_update_tx() {
 			tx_bob.clone()
 		));
 
-		// Test #2: Bob valid period has passed. Now the transaction should fail.
+		// Test #2: Bob delegate period has passed. Now the transaction should fail.
 		System::set_block_number(2 + valid_block_offset);
 		assert_noop!(DId::upsert_attribute_from_offchain_signature(
 			Origin::signed(bob_public.clone()),

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,10 +1,9 @@
-use crate::{mock::*, AttributeTransaction, Error};
-use codec::Encode;
+use crate::{mock::*, AttributeUpdateTx, Error};
 use frame_support::{assert_noop, assert_ok};
 use sp_core::Pair;
 
 #[test]
-fn validate_owner_signature() {
+fn allows_owner_attr_update_tx() {
 	new_test_ext().execute_with(|| {
 		// Create a DId account
 		let (_, did_public) = account("My Organization");
@@ -13,20 +12,32 @@ fn validate_owner_signature() {
 		let (satoshi_pair, satoshi_public) = account("Satoshi");
 
 		// Test: Should be able to register a new DId
-		assert_ok(!DID::register_did(Origin::signed(satoshi_public.clone()), did_public));
-
-		// Encode and sign a message.
-		let msg = "I am Satoshi Nakamoto".encode();
-		let satoshi_sig = satoshi_pair.sign(&msg);
+		assert_ok!(DId::register_did(Origin::signed(satoshi_public.clone()), did_public));
 
 		// Test: Should accept DId's owner signature
-		assert(DID::valid_signer_and_signature(&did_public, &satoshi_sig, &msg, &satoshi_public));
+		let name = b"attribute name";
+		let value = b"attribute value";
+		let msg = DId::encode_dnvv(&did_public, name, value, None);
+		let tx_satoshi = AttributeUpdateTx {
+			did: did_public,
+			name: name.to_vec(),
+			value: value.to_vec(),
+			valid_till: None,
+			signature: satoshi_pair.sign(&msg)
+		};
+		assert_ok!(DId::execute(Origin::signed(satoshi_public.clone()), tx_satoshi));
 
-		// Test: Should not accept someone masquerading as the owner, Satoshi
-		let (bob_pair, _) = account("Bob");
-		let bob_sig = bob_pair.sign(&msg);
-
-		assert(!DID::valid_signer_and_signature(&did_public, &bob_sig, &msg, &satoshi_public));
+		// Test: Should not accept other ppl to update
+		let (bob_pair, bob_public) = account("Bob");
+		let tx_bob = AttributeUpdateTx {
+			did: did_public,
+			name: name.to_vec(),
+			value: value.to_vec(),
+			valid_till: None,
+			signature: bob_pair.sign(&msg)
+		};
+		assert_noop!(DId::execute(Origin::signed(bob_public.clone()), tx_bob),
+			Error::<Test>::InvalidDelegate);
 	});
 }
 
@@ -42,82 +53,17 @@ fn validate_delegate_signature() {
 		let (satoshi_pair, satoshi_public) = account("Satoshi");
 		let (bob_pair, bob_public) = account("Bob");
 
-		assert_ok(!DID::register_did(Origin::signed(satoshi_public.clone()), did_public));
+		assert_ok!(DId::register_did(Origin::signed(satoshi_public.clone()), did_public));
 
 		let valid_block_offset = 5;
 
 		// Test: Adding Bob as delegate should succeed
-		assert_ok(!DID::upsert_delegate(Origin::signed(satoshi_public.clone()),
-			did_public, crate::OFFCHAIN_TX_DELEGATE_TYPE, bob_public, Some(valid_block_offset)));
-
-		let msg = "I am Satoshi Nakamoto".encode();
-		let bob_sig = bob_pair.sign(&msg);
-
-		System::set_block_number(valid_block_offset + 1);
-
-		// Test: The delegate signature should be valid during the delegation period
-		assert(DID::valid_signer_and_signature(&did_public, &bob_public, &msg, &bob_sig));
-
-		System::set_block_number(valid_block_offset + 2);
-
-		// Test: The delegate signature should fail after the delegation period
-		assert(!DID::valid_signer_and_signature(&did_public, &bob_public, &msg, &bob_sig));
+		assert_ok!(DId::upsert_delegate(
+			Origin::signed(satoshi_public.clone()),
+			did_public,
+			crate::OFFCHAIN_TX_DELEGATE_TYPE.to_vec(),
+			bob_public,
+			Some(valid_block_offset)
+		));
 	});
 }
-
-// #[test]
-// fn add_on_chain_and_revoke_off_chain_attribute() {
-// 	new_test_ext().execute_with(|| {
-// 		let name = b"MyAttribute".to_vec();
-// 		let mut value = [1, 2, 3].to_vec();
-// 		let mut validity: u32 = 1000;
-
-// 		// Create a new account pair and get the public key.
-// 		let alice_pair = account_pair("Alice");
-// 		let alice_public = alice_pair.public();
-
-// 		// Add a new attribute to an identity. Valid until block 1 + 1000.
-// 		assert_ok!(DID::add_attribute(
-// 			Origin::signed(alice_public.clone()),
-// 			alice_public.clone(),
-// 			name.clone(),
-// 			value.clone(),
-// 			Some(validity.clone().into())
-// 		));
-
-// 		// Validate that the attribute contains_key and has not expired.
-// 		assert_ok!(DID::valid_attribute(&alice_public, &name, &value));
-
-// 		// Revoke attribute off-chain
-// 		// Set validity to 0 in order to revoke the attribute.
-// 		validity = 0;
-// 		value = [0].to_vec();
-// 		let mut encoded = name.encode();
-// 		encoded.extend(value.encode());
-// 		encoded.extend(validity.encode());
-// 		encoded.extend(alice_public.encode());
-
-// 		let revoke_sig = alice_pair.sign(&encoded);
-
-// 		let revoke_transaction = AttributeTransaction {
-// 			signature: revoke_sig,
-// 			name: name.clone(),
-// 			value: value.clone(),
-// 			validity,
-// 			signer: alice_public.clone(),
-// 			identity: alice_public.clone(),
-// 		};
-
-// 		// Revoke with off-chain signed transaction.
-// 		assert_ok!(DID::execute(
-// 			Origin::signed(alice_public.clone()),
-// 			revoke_transaction
-// 		));
-
-// 		// Validate that the attribute was revoked.
-// 		assert_noop!(
-// 			DID::valid_attribute(&alice_public, &name, &[1, 2, 3].to_vec()),
-// 			Error::<Test>::InvalidAttribute
-// 		);
-// 	});
-// }

--- a/types.json
+++ b/types.json
@@ -1,16 +1,16 @@
 {
-  "DId": "AccountId",
+	"DId": "AccountId",
 	"Attribute": {
 		"name": "Vec<u8>",
 		"value": "Vec<u8>",
 		"valid_till": "Option<BlockNumber>",
 		"nonce": "u64"
 	},
-  "AttributeUpdateTx": {
-    "did": "DId",
-    "name": "Vec<u8>",
-    "value": "Vec<u8>",
-    "valid_till": "Option<BlockNumber>",
-    "signature": "Signature"
-  }
+	"AttributeUpdateTx": {
+		"did": "DId",
+		"name": "Vec<u8>",
+		"value": "Vec<u8>",
+		"valid_till": "Option<BlockNumber>",
+		"signature": "Signature"
+	}
 }

--- a/types.json
+++ b/types.json
@@ -1,0 +1,18 @@
+{
+	"Attribute": {
+		"name": "Vec<u8>",
+		"value": "Vec<u8>",
+		"created_at": "BlockNumber",
+		"valid_for": "BlockNumber",
+		"nonce": "u64"
+	},
+  "AttributeTransaction": {
+    "signature": "Signature",
+    "name": "Vec<u8>",
+    "value": "Vec<u8>",
+    "validity": "u32",
+    "signer": "AccountId",
+    "identity": "AccountId"
+  },
+  "DId": "AccountId"
+}

--- a/types.json
+++ b/types.json
@@ -1,18 +1,16 @@
 {
+  "DId": "AccountId",
 	"Attribute": {
 		"name": "Vec<u8>",
 		"value": "Vec<u8>",
-		"created_at": "BlockNumber",
-		"valid_for": "BlockNumber",
+		"valid_till": "Option<BlockNumber>",
 		"nonce": "u64"
 	},
-  "AttributeTransaction": {
-    "signature": "Signature",
+  "AttributeUpdateTx": {
+    "did": "DId",
     "name": "Vec<u8>",
     "value": "Vec<u8>",
-    "validity": "u32",
-    "signer": "AccountId",
-    "identity": "AccountId"
-  },
-  "DId": "AccountId"
+    "valid_till": "Option<BlockNumber>",
+    "signature": "Signature"
+  }
 }


### PR DESCRIPTION
@riusricardo Ricardo, this is pallet-did refactored code without using register-did. So all DId belongs to itself first until `change_owner` is called.